### PR TITLE
Address Copilot review: 10 fixes across CMap building, PUA rendering, and packaging

### DIFF
--- a/_pdf_utils.py
+++ b/_pdf_utils.py
@@ -1,0 +1,24 @@
+import pikepdf
+
+
+FONT_PROGRAM_KEYS: tuple[tuple[str, str], ...] = (
+    ("/FontFile2", "TrueType"),
+    ("/FontFile3", "CFF/OpenType"),
+    ("/FontFile", "Type1"),
+)
+
+
+def font_program_stream(font_obj: pikepdf.Object) -> tuple[pikepdf.Object | None, str | None]:
+    # Type0 composite fonts wrap a CIDFont descendant; the descriptor and embedded
+    # program live on the descendant, not the wrapper.
+    descriptor = font_obj.get("/FontDescriptor")
+    if descriptor is None and font_obj.get("/Subtype") == "/Type0":
+        descendants = font_obj.get("/DescendantFonts")
+        if descendants:
+            descriptor = descendants[0].get("/FontDescriptor")
+    if descriptor is None:
+        return None, None
+    for key, kind in FONT_PROGRAM_KEYS:
+        if key in descriptor:
+            return descriptor[key], kind
+    return None, None

--- a/extract_fonts.py
+++ b/extract_fonts.py
@@ -5,21 +5,7 @@ from pathlib import Path
 import pikepdf
 from fontTools.ttLib import TTFont
 
-
-def font_program_stream(font_obj: pikepdf.Object) -> tuple[pikepdf.Object | None, str]:
-    descriptor = font_obj.get("/FontDescriptor")
-    if descriptor is None and font_obj.get("/Subtype") == "/Type0":
-        descendants = font_obj.get("/DescendantFonts")
-        if descendants:
-            descriptor = descendants[0].get("/FontDescriptor")
-
-    if descriptor is None:
-        return None, "no /FontDescriptor"
-
-    for key, kind in (("/FontFile2", "TrueType"), ("/FontFile3", "CFF/OpenType"), ("/FontFile", "Type1")):
-        if key in descriptor:
-            return descriptor[key], kind
-    return None, "no embedded font program"
+from _pdf_utils import font_program_stream
 
 
 def font_name(font_obj: pikepdf.Object) -> str:
@@ -85,7 +71,7 @@ def main() -> None:
             seen.add(name)
 
             stream, kind = font_program_stream(obj)
-            print(f"\n{name}  [{kind}]")
+            print(f"\n{name}  [{kind or 'no embedded program'}]")
             if stream is None:
                 continue
             inspect_font(name, stream, kind, args.out)

--- a/extract_fonts.py
+++ b/extract_fonts.py
@@ -58,23 +58,24 @@ def main() -> None:
         parser.error(f"PDF not found: {args.pdf}")
     args.out.mkdir(parents=True, exist_ok=True)
 
-    seen: set[str] = set()
+    seen: set[int] = set()
     with pikepdf.open(args.pdf) as pdf:
         for obj in pdf.objects:
             if not isinstance(obj, pikepdf.Dictionary):
                 continue
             if obj.get("/Type") != "/Font":
                 continue
-            name = font_name(obj)
-            if name in seen:
+            obj_id = obj.objgen[0]
+            if obj_id in seen:
                 continue
-            seen.add(name)
+            seen.add(obj_id)
 
+            name = font_name(obj)
             stream, kind = font_program_stream(obj)
             print(f"\n{name}  [{kind or 'no embedded program'}]")
             if stream is None:
                 continue
-            inspect_font(name, stream, kind, args.out)
+            inspect_font(name, obj_id, stream, kind, args.out)
 
 
 if __name__ == "__main__":

--- a/extract_fonts.py
+++ b/extract_fonts.py
@@ -13,10 +13,10 @@ def font_name(font_obj: pikepdf.Object) -> str:
     return str(name).lstrip("/")
 
 
-def inspect_font(name: str, stream: pikepdf.Object, kind: str, dump_dir: Path) -> None:
+def inspect_font(name: str, obj_id: int, stream: pikepdf.Object, kind: str, dump_dir: Path) -> None:
     raw = stream.read_bytes()
     suffix = {"TrueType": "ttf", "CFF/OpenType": "otf", "Type1": "pfb"}.get(kind, "bin")
-    out_path = dump_dir / f"{name}.{suffix}"
+    out_path = dump_dir / f"{name}-obj{obj_id}.{suffix}"
     out_path.write_bytes(raw)
 
     if kind == "Type1":

--- a/fix_pdf_fonts.py
+++ b/fix_pdf_fonts.py
@@ -57,15 +57,17 @@ def build_cmap(glyph_names: list[str], overrides: dict[int, str] | None = None) 
     entries: list[tuple[str, str]] = []
     override_count = 0
     for gid, name in enumerate(glyph_names):
-        if gid in overrides:
+        is_override = gid in overrides
+        if is_override:
             u = overrides[gid]
-            override_count += 1
         else:
             u = name_to_unicode(name)
             if not u or is_all_pua(u):
                 continue
         if not u:
             continue
+        if is_override:
+            override_count += 1
         cid_hex = f"{gid:04X}"
         unicode_hex = "".join(f"{ord(c):04X}" for c in u)
         entries.append((cid_hex, unicode_hex))

--- a/fix_pdf_fonts.py
+++ b/fix_pdf_fonts.py
@@ -149,7 +149,7 @@ def main() -> None:
                 print(f"  {name}: no mappable glyph names — left untouched")
                 continue
 
-            new_stream = pdf.make_stream(cmap_content.encode("latin-1"))
+            new_stream = pdf.make_stream(cmap_content.encode("ascii"))
             obj["/ToUnicode"] = new_stream
             extra = f" (+{manual_used} manual)" if manual_used else ""
             print(f"  {name}: mapped {mapped}/{len(glyph_names)} glyphs{extra}")

--- a/fix_pdf_fonts.py
+++ b/fix_pdf_fonts.py
@@ -7,6 +7,8 @@ import pikepdf
 from fontTools import agl
 from fontTools.ttLib import TTFont
 
+from _pdf_utils import font_program_stream
+
 
 def name_to_unicode(name: str) -> str | None:
     if not name or name in {".notdef", ".null"} or name.startswith("glyph"):
@@ -95,20 +97,6 @@ def build_cmap(glyph_names: list[str], overrides: dict[int, str] | None = None) 
     return "\n".join(lines), len(entries), override_count
 
 
-def font_program_stream(font_obj: pikepdf.Object) -> pikepdf.Object | None:
-    descriptor = font_obj.get("/FontDescriptor")
-    if descriptor is None and font_obj.get("/Subtype") == "/Type0":
-        descendants = font_obj.get("/DescendantFonts")
-        if descendants:
-            descriptor = descendants[0].get("/FontDescriptor")
-    if descriptor is None:
-        return None
-    for key in ("/FontFile2", "/FontFile3", "/FontFile"):
-        if key in descriptor:
-            return descriptor[key]
-    return None
-
-
 def main() -> None:
     parser = argparse.ArgumentParser(description="Inject corrected ToUnicode CMaps from glyph names.")
     parser.add_argument("pdf", type=Path)
@@ -141,7 +129,7 @@ def main() -> None:
             seen.add(obj_id)
 
             name = str(obj.get("/BaseFont") or obj.get("/FontName") or "<unnamed>").lstrip("/")
-            stream = font_program_stream(obj)
+            stream, _ = font_program_stream(obj)
             if stream is None:
                 print(f"  {name}: skipped (no embedded program)")
                 continue

--- a/fix_pdf_fonts.py
+++ b/fix_pdf_fonts.py
@@ -130,6 +130,8 @@ def main() -> None:
             if obj.get("/Type") != "/Font":
                 continue
             subtype = obj.get("/Subtype")
+            # Skip CIDFont descendants: ToUnicode lives on the Type0 wrapper that
+            # references them, and we'll process that wrapper on its own iteration.
             if subtype in ("/CIDFontType0", "/CIDFontType2"):
                 continue
             obj_id = obj.objgen[0]

--- a/fix_pdf_fonts.py
+++ b/fix_pdf_fonts.py
@@ -159,6 +159,8 @@ def main() -> None:
                 continue
 
             if not args.dry_run:
+                # CMap syntax is pure ASCII (PDF spec §10.8); encode as ascii to
+                # catch any accidental non-ASCII content early rather than silently.
                 new_stream = pdf.make_stream(cmap_content.encode("ascii"))
                 obj["/ToUnicode"] = new_stream
             extra = f" (+{manual_used} manual)" if manual_used else ""

--- a/fix_pdf_fonts.py
+++ b/fix_pdf_fonts.py
@@ -102,12 +102,19 @@ def build_cmap(glyph_names: list[str], overrides: dict[int, str] | None = None) 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Inject corrected ToUnicode CMaps from glyph names.")
     parser.add_argument("pdf", type=Path)
-    parser.add_argument("-o", "--output", type=Path, required=True)
+    parser.add_argument("-o", "--output", type=Path, help="Output PDF path. Required unless --dry-run.")
     parser.add_argument("--mapping", type=Path, default=None, help="Manual PUA-glyph mapping file.")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the per-font summary without writing an output PDF.",
+    )
     args = parser.parse_args()
 
     if not args.pdf.is_file():
         parser.error(f"PDF not found: {args.pdf}")
+    if not args.dry_run and args.output is None:
+        parser.error("-o/--output is required unless --dry-run is set")
 
     manual: dict[str, dict[int, str]] = {}
     if args.mapping and args.mapping.is_file():
@@ -149,13 +156,17 @@ def main() -> None:
                 print(f"  {name}: no mappable glyph names — left untouched")
                 continue
 
-            new_stream = pdf.make_stream(cmap_content.encode("ascii"))
-            obj["/ToUnicode"] = new_stream
+            if not args.dry_run:
+                new_stream = pdf.make_stream(cmap_content.encode("ascii"))
+                obj["/ToUnicode"] = new_stream
             extra = f" (+{manual_used} manual)" if manual_used else ""
             print(f"  {name}: mapped {mapped}/{len(glyph_names)} glyphs{extra}")
 
-        pdf.save(args.output)
-    print(f"\nWrote {args.output}")
+        if args.dry_run:
+            print("\nDry run — no output written.")
+        else:
+            pdf.save(args.output)
+            print(f"\nWrote {args.output}")
 
 
 if __name__ == "__main__":

--- a/inspect_fonts.py
+++ b/inspect_fonts.py
@@ -23,24 +23,24 @@ def span_is_broken(text: str) -> bool:
 
 
 def inspect(pdf_path: Path, examples_per_font: int) -> None:
-    doc = pymupdf.open(pdf_path)
     broken_counts: dict[str, int] = defaultdict(int)
     total_counts: dict[str, int] = defaultdict(int)
     examples: dict[str, list[tuple[int, str]]] = defaultdict(list)
 
-    for page in doc:
-        for block in page.get_text("dict")["blocks"]:
-            for line in block.get("lines", []):
-                for span in line.get("spans", []):
-                    font = span.get("font", "<unknown>")
-                    text = span.get("text", "")
-                    if not text.strip():
-                        continue
-                    total_counts[font] += 1
-                    if span_is_broken(text):
-                        broken_counts[font] += 1
-                        if len(examples[font]) < examples_per_font:
-                            examples[font].append((page.number, text))
+    with pymupdf.open(pdf_path) as doc:
+        for page in doc:
+            for block in page.get_text("dict")["blocks"]:
+                for line in block.get("lines", []):
+                    for span in line.get("spans", []):
+                        font = span.get("font", "<unknown>")
+                        text = span.get("text", "")
+                        if not text.strip():
+                            continue
+                        total_counts[font] += 1
+                        if span_is_broken(text):
+                            broken_counts[font] += 1
+                            if len(examples[font]) < examples_per_font:
+                                examples[font].append((page.number, text))
 
     print(f"{'Font':<45} {'Broken':>8} {'Total':>8} {'Ratio':>8}")
     print("-" * 71)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,3 +10,22 @@ dependencies = [
     "pillow>=10.4.0",
     "pymupdf>=1.27.2",
 ]
+
+[project.scripts]
+pdf-cmap-inspect = "inspect_fonts:main"
+pdf-cmap-extract = "extract_fonts:main"
+pdf-cmap-render-pua = "render_pua_glyphs:main"
+pdf-cmap-fix = "fix_pdf_fonts:main"
+
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+py-modules = [
+    "_pdf_utils",
+    "extract_fonts",
+    "fix_pdf_fonts",
+    "inspect_fonts",
+    "render_pua_glyphs",
+]

--- a/render_pua_glyphs.py
+++ b/render_pua_glyphs.py
@@ -15,28 +15,45 @@ COLS = 8
 PAD = 4
 
 
+def pua_codepoints(name: str) -> list[int] | None:
+    """Codepoints encoded in an Adobe-style glyph name, if all are in the PUA.
+
+    Recognizes uXXXX, uniXXXX, and multi-codepoint uniXXXXYYYY... ligatures.
+    Returns None if the name isn't one of those forms or any codepoint falls
+    outside the BMP PUA range.
+    """
+    if name.startswith("uni") and len(name) > 3 and (len(name) - 3) % 4 == 0:
+        try:
+            cps = [int(name[i : i + 4], 16) for i in range(3, len(name), 4)]
+        except ValueError:
+            return None
+    elif name.startswith("u") and 5 <= len(name) <= 7:
+        try:
+            cps = [int(name[1:], 16)]
+        except ValueError:
+            return None
+    else:
+        return None
+    if not all(0xE000 <= cp <= 0xF8FF for cp in cps):
+        return None
+    return cps
+
+
 def is_pua_name(name: str) -> bool:
-    if not name.startswith("uni") or len(name) != 7:
-        return False
-    try:
-        cp = int(name[3:], 16)
-    except ValueError:
-        return False
-    return 0xE000 <= cp <= 0xF8FF
+    return pua_codepoints(name) is not None
 
 
-def render_glyph(ttf_bytes: bytes, codepoint: int, size: int = 64) -> Image.Image:
+def render_glyph(ttf_bytes: bytes, text: str, size: int = 64) -> Image.Image:
     cell = Image.new("RGB", (CELL, CELL), "white")
     draw = ImageDraw.Draw(cell)
     try:
         pil_font = ImageFont.truetype(io.BytesIO(ttf_bytes), size=size)
-        ch = chr(codepoint)
-        bbox = draw.textbbox((0, 0), ch, font=pil_font)
+        bbox = draw.textbbox((0, 0), text, font=pil_font)
         w = bbox[2] - bbox[0]
         h = bbox[3] - bbox[1]
         x = (CELL - w) // 2 - bbox[0]
         y = (CELL - h) // 2 - bbox[1]
-        draw.text((x, y), ch, font=pil_font, fill="black")
+        draw.text((x, y), text, font=pil_font, fill="black")
     except Exception as exc:
         draw.text((4, 4), f"err\n{exc.__class__.__name__}", fill="red")
     return cell
@@ -59,10 +76,10 @@ def make_grid(font_name: str, items: list[tuple[int, str]], ttf_bytes: bytes) ->
         row = i // COLS
         x = PAD + col * (CELL + PAD)
         y = 30 + row * (CELL + LABEL_H + PAD)
-        try:
-            cp = int(name[3:], 16)
-            cell = render_glyph(ttf_bytes, cp)
-        except Exception:
+        cps = pua_codepoints(name)
+        if cps:
+            cell = render_glyph(ttf_bytes, "".join(chr(cp) for cp in cps))
+        else:
             cell = Image.new("RGB", (CELL, CELL), "lightgray")
         img.paste(cell, (x, y))
         label = f"GID {gid:#06x}"

--- a/render_pua_glyphs.py
+++ b/render_pua_glyphs.py
@@ -6,25 +6,13 @@ import pikepdf
 from fontTools.ttLib import TTFont
 from PIL import Image, ImageDraw, ImageFont
 
+from _pdf_utils import font_program_stream
+
 
 CELL = 96
 LABEL_H = 22
 COLS = 8
 PAD = 4
-
-
-def font_program_stream(font_obj: pikepdf.Object) -> pikepdf.Object | None:
-    descriptor = font_obj.get("/FontDescriptor")
-    if descriptor is None and font_obj.get("/Subtype") == "/Type0":
-        descendants = font_obj.get("/DescendantFonts")
-        if descendants:
-            descriptor = descendants[0].get("/FontDescriptor")
-    if descriptor is None:
-        return None
-    for key in ("/FontFile2", "/FontFile3", "/FontFile"):
-        if key in descriptor:
-            return descriptor[key]
-    return None
 
 
 def is_pua_name(name: str) -> bool:
@@ -117,7 +105,7 @@ def main() -> None:
             seen.add(obj_id)
 
             name = str(obj.get("/BaseFont") or obj.get("/FontName") or "<unnamed>").lstrip("/")
-            stream = font_program_stream(obj)
+            stream, _ = font_program_stream(obj)
             if stream is None:
                 continue
             ttf_bytes = stream.read_bytes()

--- a/render_pua_glyphs.py
+++ b/render_pua_glyphs.py
@@ -15,6 +15,9 @@ COLS = 8
 PAD = 4
 
 
+UNI_PREFIX_LEN = 3  # length of the "uni" prefix in uniXXXX glyph names
+
+
 def pua_codepoints(name: str) -> list[int] | None:
     """Codepoints encoded in an Adobe-style glyph name, if all are in the PUA.
 
@@ -22,9 +25,9 @@ def pua_codepoints(name: str) -> list[int] | None:
     Returns None if the name isn't one of those forms or any codepoint falls
     outside the BMP PUA range.
     """
-    if name.startswith("uni") and len(name) > 3 and (len(name) - 3) % 4 == 0:
+    if name.startswith("uni") and len(name) > UNI_PREFIX_LEN and (len(name) - UNI_PREFIX_LEN) % 4 == 0:
         try:
-            cps = [int(name[i : i + 4], 16) for i in range(3, len(name), 4)]
+            cps = [int(name[i : i + 4], 16) for i in range(UNI_PREFIX_LEN, len(name), 4)]
         except ValueError:
             return None
     elif name.startswith("u") and 5 <= len(name) <= 7:


### PR DESCRIPTION
## Summary

Addresses 10 of 13 Copilot review comments as separate commits.

**Bugs fixed**
- `build_cmap` no longer counts overrides whose value would be filtered out (Issue 1)
- CMap stream encoded as ASCII instead of latin-1 (Issue 3)
- `is_pua_name` now recognizes `u`-prefix and multi-codepoint PUA glyph names — they were silently skipped before, blocking the manual mapping flow (Issue 2)
- `extract_fonts` deduplicates by PDF object ID, matching `fix_pdf_fonts` (Issue 4)
- Dumped font filenames now include the object ID so colliding `BaseFont` names don't clobber each other (Issue 10)
- `inspect_fonts` opens the `pymupdf.Document` via `with` (Issue 7)

**Enhancements**
- Shared `font_program_stream` extracted into `_pdf_utils.py` to stop the three-way drift (Issue 9)
- `--dry-run` flag in `fix_pdf_fonts` for previewing changes without writing output (Issue 13)
- `[project.scripts]` entry points: `pdf-cmap-fix`, `pdf-cmap-inspect`, `pdf-cmap-extract`, `pdf-cmap-render-pua` (Issue 11)
- Comment near the CIDFont skip in `fix_pdf_fonts` explaining the Type0 wrapper/descendant relationship (Issue 5)

**Not implemented**
- Issue 6 (GID-based rasterizer): real concern, but a non-trivial rewrite — left for a follow-up.
- Issue 8 (strict u-prefix validation): leniency is the right call for non-conformant PDFs.
- Issue 12 (tests): worth doing as its own PR.

## Test plan
- [ ] `uv sync` succeeds with the new build-system block
- [ ] `uv run pdf-cmap-fix input.pdf --dry-run` prints the per-font summary and writes nothing
- [ ] `uv run pdf-cmap-fix input.pdf -o out.pdf` produces a working fixed PDF
- [ ] `uv run pdf-cmap-render-pua input.pdf` renders glyphs for both `uniE0XX` and `uE0XX` named PUA glyphs
- [ ] `uv run pdf-cmap-extract input.pdf` writes uniquely-named files when the PDF has duplicate `BaseFont` names