### PR TITLE
Add ruff config and GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v4
+        with:
+          python-version: "3.12"
+      - run: uv sync
+      - run: uv run ruff check
+      - run: uv run ruff format --check
+      - run: uv run python -m compileall -q .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: astral-sh/setup-uv@v4
         with:
           python-version: "3.12"
-      - run: uv sync
+      - run: uv sync --group dev
       - run: uv run ruff check
       - run: uv run ruff format --check
       - run: uv run python -m compileall -q .

--- a/_pdf_utils.py
+++ b/_pdf_utils.py
@@ -1,6 +1,5 @@
 import pikepdf
 
-
 FONT_PROGRAM_KEYS: tuple[tuple[str, str], ...] = (
     ("/FontFile2", "TrueType"),
     ("/FontFile3", "CFF/OpenType"),

--- a/extract_fonts.py
+++ b/extract_fonts.py
@@ -41,8 +41,7 @@ def inspect_font(name: str, obj_id: int, stream: pikepdf.Object, kind: str, dump
 
     print(f"  saved {out_path.name} ({len(raw)} bytes)")
     print(
-        f"    glyphs: {total}, named: {named} ({named/total:.0%}), "
-        f"post: {has_post}, cmap: {has_cmap}, CFF: {has_cff}"
+        f"    glyphs: {total}, named: {named} ({named / total:.0%}), post: {has_post}, cmap: {has_cmap}, CFF: {has_cff}"
     )
     if sample:
         print(f"    sample names: {sample}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,3 +31,14 @@ py-modules = [
     "inspect_fonts",
     "render_pua_glyphs",
 ]
+
+[dependency-groups]
+dev = [
+    "ruff>=0.6",
+]
+
+[tool.ruff]
+line-length = 120
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B"]

--- a/render_pua_glyphs.py
+++ b/render_pua_glyphs.py
@@ -8,7 +8,6 @@ from PIL import Image, ImageDraw, ImageFont
 
 from _pdf_utils import font_program_stream
 
-
 CELL = 96
 LABEL_H = 22
 COLS = 8


### PR DESCRIPTION
## Summary

- Adds a `[tool.ruff]` config in `pyproject.toml` (line-length 120, rules `E,F,I,UP,B`) and declares ruff in a `[dependency-groups] dev` group.
- Applies ruff's autofixes to the existing tree (import sort in `_pdf_utils.py` and `render_pua_glyphs.py`, one line merge in `extract_fonts.py`).
- Adds `.github/workflows/ci.yml` running `ruff check`, `ruff format --check`, and `python -m compileall` on push to main and on every PR.

## Test plan
- [ ] CI workflow runs and passes on this PR
- [ ] `uv sync && uv run ruff check && uv run ruff format --check` passes locally